### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,15 +1,21 @@
 name: Go
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - feat-*
+      - ci
+    tags:
+      - v*
+
+env:
+  GO_VERSION: "1.22"
+  GHCR_REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ["1.21", "1.22"]
-    name: Lint ${{ matrix.go-version == '1.22' && '(latest)' || '(old)' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -17,11 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ env.GO_VERSION }}
           cache: true
-
-      - name: Install libolm
-        run: sudo apt-get install libolm-dev libolm3
 
       - name: Install goimports
         run: |
@@ -34,5 +37,76 @@ jobs:
       - name: Lint
         run: pre-commit run -a
 
+  # test:
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - uses: actions/checkout@v4
+
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
+  #         cache: true
+
+  #     - name: Install libolm and other dependencies
+  #       run: sudo apt-get install libolm-dev libolm3 gobjc++-mingw-w64 gcc g++ build-essential
+
+  #     - name: Set up gotestfmt
+  #       uses: GoTestTools/gotestfmt-action@v2
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Run tests
+  #       run: |
+  #         go test -v -json ./... -cover | gotestfmt
+
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install libolm
+        run: sudo apt-get install libolm-dev libolm3 gobjc++-mingw-w64
+
       - name: Build
         run: go build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.GHCR_REGISTRY_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=long
+            type=raw,latest
+
+      - name: Docker Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ci
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.GHCR_REGISTRY_IMAGE }}:latest
+          cache-to: type=inline


### PR DESCRIPTION
This pull request primarily focuses on refining the GitHub Actions workflow (`go.yml`) for the project. The changes include modifying the triggering events for the workflow, setting a fixed Go version, removing unnecessary steps, and adding a new Docker build and push job. The test job has been commented out, suggesting it may be used in the future.

Key changes are:

Workflow triggering events:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL3-L25): The workflow now triggers on push events to `master`, `feat-*`, and `ci` branches, as well as on tags starting with `v`. Previously, it triggered on every push and pull request.

Go version:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL3-L25): The Go version has been fixed to "1.22" across the workflow. Previously, it was set to either "1.21" or "1.22" based on a matrix strategy.

Removed steps:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL3-L25): The `Install libolm` step has been removed from the `lint` job.

Added Docker build and push job:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR40-R112): A new `build-docker` job has been added that builds a Docker image and pushes it to the GitHub Container Registry. This includes steps for setting up Docker Buildx, logging into the Docker registry, setting Docker metadata, and building and pushing the Docker image.

Commented out test job:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR40-R112): A `test` job has been added but is currently commented out. This suggests it may be used in the future. It includes steps for setting up Go, installing dependencies, setting up `gotestfmt`, and running tests.