### PR TITLE
Update ci again

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -77,7 +77,7 @@ jobs:
         run: sudo apt-get install libolm-dev libolm3 gobjc++-mingw-w64
 
       - name: Build
-        run: go build
+        run: bash ./build.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,14 +1,29 @@
-FROM alpine:3.19
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ENV UID=1337 \
-    GID=1337
+ENV UID=1000 \
+    GID=1000
 
-RUN apk add --no-cache ffmpeg su-exec ca-certificates bash jq curl yq olm
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+# Install dependencies using microdnf
+RUN microdnf install -y \
+    shadow-utils \
+    ca-certificates \
+    bash \
+    jq \
+    libolm \
+    && microdnf clean all
+
+RUN curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 
 ARG EXECUTABLE=./mautrix-imessage
 COPY $EXECUTABLE /usr/bin/mautrix-imessage
 COPY ./example-config.yaml /opt/mautrix-imessage/example-config.yaml
 COPY ./docker-run.sh /docker-run.sh
+
+# Ensure the entrypoint script is executable
+RUN chmod +x /docker-run.sh /usr/bin/mautrix-imessage
+
 VOLUME /data
 
 CMD ["/docker-run.sh"]

--- a/build.sh
+++ b/build.sh
@@ -14,4 +14,4 @@ if [[ -f "$HEIF_PATH/libheif.1.dylib" ]]; then
 	build_tags="libheif"
 fi
 
-go build -tags "$build_tags" -ldflags "-X main.Tag=$(git describe --exact-match --tags 2>/dev/null) -X main.Commit=$(git rev-parse HEAD) -X 'main.BuildTime=`date '+%b %_d %Y, %H:%M:%S'`'" "$@"
+go build -o mautrix-imessage -tags "$build_tags" -ldflags "-X main.Tag=$(git describe --exact-match --tags 2>/dev/null) -X main.Commit=$(git rev-parse HEAD) -X 'main.BuildTime=`date '+%b %_d %Y, %H:%M:%S'`'" "$@"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -4,16 +4,6 @@ if [[ -z "$GID" ]]; then
 	GID="$UID"
 fi
 
-# Define functions.
-function fixperms {
-	chown -R $UID:$GID /data
-
-	# /opt/mautrix-imessage is read-only, so disable file logging if it's pointing there.
-	if [[ "$(yq e '.logging.writers[1].filename' /data/config.yaml)" == "./logs/mautrix-imessage.log" ]]; then
-		yq -I4 e -i 'del(.logging.writers[1])' /data/config.yaml
-	fi
-}
-
 if [[ ! -f /data/config.yaml ]]; then
 	cp /opt/mautrix-imessage/example-config.yaml /data/config.yaml
 	echo "Didn't find a config file."
@@ -32,5 +22,7 @@ if [[ ! -f /data/registration.yaml ]]; then
 fi
 
 cd /data
-fixperms
-exec su-exec $UID:$GID /usr/bin/mautrix-imessage
+
+chown -R $UID:$GID /data
+#exec su-exec $UID:$GID /usr/bin/mautrix-imessage
+exec /usr/bin/mautrix-imessage


### PR DESCRIPTION
This pull request includes significant changes to the build process and the Docker environment setup. The most important changes include switching the Docker base image, changing the build command in the GitHub workflow, modifying the build script, and simplifying the Docker run script.

Changes to the Docker environment:

* [`Dockerfile.ci`](diffhunk://#diff-3aaadfe559b0ea24d6dc905d46cee17a924a3f0c047906c270d00254d5258ef2L1-R26): Switched the base image from `alpine:3.19` to `registry.access.redhat.com/ubi9/ubi-minimal:latest` and updated the environment variables `UID` and `GID`. Also, replaced the `apk add` command with `microdnf install` to install dependencies and ensured the entrypoint script is executable.

Changes to the build process:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL80-R80): Replaced the `go build` command with `bash ./build.sh` in the GitHub workflow.
* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L17-R17): Modified the `go build` command to include the `-o mautrix-imessage` flag, which specifies the output file name.

Changes to the Docker run script:

* [`docker-run.sh`](diffhunk://#diff-360c358e5fc4de52699ff11376043b7c67ebccc164c8dd9bc2b025782d681279L7-L16): Removed the `fixperms` function and instead directly executed the `chown` command to change the ownership of the `/data` directory. Also, replaced the `su-exec` command with a direct execution of `/usr/bin/mautrix-imessage`. [[1]](diffhunk://#diff-360c358e5fc4de52699ff11376043b7c67ebccc164c8dd9bc2b025782d681279L7-L16) [[2]](diffhunk://#diff-360c358e5fc4de52699ff11376043b7c67ebccc164c8dd9bc2b025782d681279L35-R28)