### PR TITLE
MS-58: Enable automatic room migration to direct chats

### DIFF
--- a/custompuppet.go
+++ b/custompuppet.go
@@ -100,13 +100,13 @@ func (user *User) tryAutomaticRoomMigrationToDirectChats() {
 
 	user.zlog.Debug().Msg("Automatic room migration enabled")
 
-	portals:= user.bridge.GetAllPortals()
-	directs:= user.getDirectChats()
-	userId:= user.GetMXID()
-	usersDirects:= directs[userId]
-	roomsToMigrate:= []id.RoomID{}
+	portals := user.bridge.GetAllPortals()
+	directs := user.getDirectChats()
+	userId := user.GetMXID()
+	usersDirects := directs[userId]
+	roomsToMigrate := []id.RoomID{}
 
-	for _, portal:= range portals {
+	for _, portal := range portals {
 		if !contains(usersDirects, portal.MXID) {
 			roomsToMigrate = append(roomsToMigrate, portal.MXID)
 		}

--- a/main.go
+++ b/main.go
@@ -482,6 +482,7 @@ func (br *IMBridge) Start() {
 	br.ZLog.Debug().Msg("Finding bridge user")
 	br.user = br.loadDBUser()
 	br.user.tryAutomaticDoublePuppeting()
+	br.user.tryAutomaticRoomMigrationToDirectChats()
 
 	// If this bridge is in OnlyBackfill mode, then only run the backfill
 	// queue and the IPC listener, and not the new message listeners.


### PR DESCRIPTION
This pull request introduces a new feature for automatic room migration to direct chats and includes a helper function to check for room membership. The changes are primarily focused on enhancing user experience by automating the migration process.

New feature for automatic room migration:

* [`custompuppet.go`](diffhunk://#diff-68c9698dec6d9be02b0da3cb7f893af5d47460632eab8454ea2a5d98dc082ac2R83-R118): Added the `tryAutomaticRoomMigrationToDirectChats` method to the `User` struct to handle the automatic migration of rooms to direct chats. This method checks if the feature is enabled, gathers the necessary data, and updates the direct chats accordingly.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R485): Modified the `Start` method in the `IMBridge` struct to call the new `tryAutomaticRoomMigrationToDirectChats` method, ensuring that the migration process is triggered when the bridge starts.

Helper function:

* [`custompuppet.go`](diffhunk://#diff-68c9698dec6d9be02b0da3cb7f893af5d47460632eab8454ea2a5d98dc082ac2R83-R118): Added the `contains` function to check if a specific room ID exists within a slice of room IDs, which is used within the new migration method.